### PR TITLE
Update user search endpoint

### DIFF
--- a/app/controllers/api/v1/users_search_controller.rb
+++ b/app/controllers/api/v1/users_search_controller.rb
@@ -1,6 +1,6 @@
 class Api::V1::UsersSearchController < ApplicationController
   def show
-    user = User.find_user_by_email(params[:email])
+    user = User.find_by(google_uid: params[:google_uid])
     if user.nil?
       render json: ErrorSerializer.no_matches_found
     else

--- a/spec/requests/api/v1/users/search_request_spec.rb
+++ b/spec/requests/api/v1/users/search_request_spec.rb
@@ -8,7 +8,7 @@ describe 'Users search API' do
 
         user = User.create!(first_name: "Bob", last_name: "Evans", phone_number: "1234567", email: "be@gmail.com", google_uid: "1234")
 
-        get "/api/v1/users/find", params: {email: user.email}
+        get "/api/v1/users/find", params: {google_uid: user.google_uid}
 
         user_response = JSON.parse(response.body, symbolize_names: true)
 
@@ -47,7 +47,7 @@ describe 'Users search API' do
       it 'returns an empty array' do
         create(:user)
 
-        get '/api/v1/users/find', params: {email: "b@email.com"}
+        get '/api/v1/users/find', params: {google_uid: ""}
 
         expect(response).to be_successful
         users = JSON.parse(response.body, symbolize_names: true)


### PR DESCRIPTION
This PR updates the endpoint "/api/v1/users/find" by replacing the email param with google_uid. Accompanying tests have also been updated. 